### PR TITLE
Resolve plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19179,7 +19179,7 @@
     },
     "packages/ymir-core-cli": {
       "name": "@onevor/ymir-core-cli",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "ISC",
       "dependencies": {
         "chalk": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19179,7 +19179,7 @@
     },
     "packages/ymir-core-cli": {
       "name": "@onevor/ymir-core-cli",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "ISC",
       "dependencies": {
         "chalk": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19233,7 +19233,7 @@
     },
     "packages/ymir-plugin-ssm": {
       "name": "@onevor/ymir-plugin-ssm",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.1212.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19224,7 +19224,7 @@
     },
     "packages/ymir-plugin-azure-key-vault": {
       "name": "@onevor/ymir-plugin-azure-key-vault",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "ISC",
       "dependencies": {
         "@azure/identity": "^3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19179,7 +19179,7 @@
     },
     "packages/ymir-core-cli": {
       "name": "@onevor/ymir-core-cli",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "ISC",
       "dependencies": {
         "chalk": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19179,7 +19179,7 @@
     },
     "packages/ymir-core-cli": {
       "name": "@onevor/ymir-core-cli",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "ISC",
       "dependencies": {
         "chalk": "^4.0.0",

--- a/packages/ymir-core-cli/package-lock.json
+++ b/packages/ymir-core-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onevor/ymir-core-cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onevor/ymir-core-cli",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "ISC",
       "dependencies": {
         "command-line-args": "^5.2.1",

--- a/packages/ymir-core-cli/package-lock.json
+++ b/packages/ymir-core-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onevor/ymir-core-cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onevor/ymir-core-cli",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "ISC",
       "dependencies": {
         "command-line-args": "^5.2.1",

--- a/packages/ymir-core-cli/package-lock.json
+++ b/packages/ymir-core-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onevor/ymir-core-cli",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onevor/ymir-core-cli",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "ISC",
       "dependencies": {
         "command-line-args": "^5.2.1",

--- a/packages/ymir-core-cli/package-lock.json
+++ b/packages/ymir-core-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onevor/ymir-core-cli",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onevor/ymir-core-cli",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "ISC",
       "dependencies": {
         "command-line-args": "^5.2.1",

--- a/packages/ymir-core-cli/package.json
+++ b/packages/ymir-core-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onevor/ymir-core-cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Manage app config and secrets",
   "main": "index.js",
   "private": false,

--- a/packages/ymir-core-cli/package.json
+++ b/packages/ymir-core-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onevor/ymir-core-cli",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Manage app config and secrets",
   "main": "index.js",
   "private": false,

--- a/packages/ymir-core-cli/package.json
+++ b/packages/ymir-core-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onevor/ymir-core-cli",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Manage app config and secrets",
   "main": "index.js",
   "private": false,

--- a/packages/ymir-core-cli/package.json
+++ b/packages/ymir-core-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onevor/ymir-core-cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Manage app config and secrets",
   "main": "index.js",
   "private": false,

--- a/packages/ymir-core-cli/src/bin/plugin-operation/index.ts
+++ b/packages/ymir-core-cli/src/bin/plugin-operation/index.ts
@@ -1,3 +1,4 @@
+import * as Chalk from 'chalk';
 import * as commandLineArgs from 'command-line-args';
 
 import * as helper from '../../lib/config/helper';
@@ -6,24 +7,33 @@ import * as installLib from '../../lib/resolve/lib/resolver-operations/install';
 import { isInProject, validateRequiredProps } from '../lib/index';
 
 import * as help from '../lib/help';
+import * as reg from '../../lib/plugin/register-plugin';
+
+const chalk: any = Chalk;
+
+const legacyInstallDef = [
+  { name: 'name', alias: 'n', type: String },
+  { name: 'alias', alias: 'a', type: String },
+  { name: 'install', alias: 'i', type: Boolean },
+  { name: 'global', alias: 'g', type: Boolean },
+  { name: 'path', alias: 'p', type: String },
+];
+
+const resolvePluginsDef = [{ name: 'force', alias: 'f', type: Boolean }];
 
 /**
  * If you install the same path with different names
  * it will create a new file, and not remove the old one
  *
  * TODO: should have options for overwrite/delete old
+ *
+ * TODO: bydefault call the plugin resolver to create plugin files
+ * add -f to overwrite existing files
  */
-export async function install(args: any, ctx: any) {
+export async function legacyInstall(args: any, ctx: any) {
   const { cwd } = ctx;
   await isInProject(true, ctx);
-  const def = [
-    { name: 'name', alias: 'n', type: String },
-    { name: 'alias', alias: 'a', type: String },
-    { name: 'install', alias: 'i', type: Boolean },
-    { name: 'global', alias: 'g', type: Boolean },
-    { name: 'path', alias: 'p', type: String },
-    help.def,
-  ];
+  const def = [...legacyInstallDef, help.def];
   const opt = commandLineArgs(def, { argv: args });
 
   if (opt.help) {
@@ -81,4 +91,80 @@ export async function install(args: any, ctx: any) {
   }
 
   console.error('Error: invalid code path, should not be able to get here');
+}
+
+export async function resolvePlugins(args: any, ctx: any) {
+  const { cwd } = ctx;
+  await isInProject(true, ctx);
+  const def = [...resolvePluginsDef, help.def];
+  const opt = commandLineArgs(def, { argv: args });
+
+  if (opt.help) {
+    return help.log(def, 'Install plugin(s)', help.getUsageText('install'));
+  }
+
+  const force =
+    (Object.prototype.hasOwnProperty.call(opt, 'force') && opt.force) || false;
+
+  const ymirPath = helper.ymirProjectFolderPath(cwd);
+  const pluginPaths = await reg.fullPluginResolve(cwd);
+
+  if (pluginPaths.length === 0) {
+    console.warn(chalk.red('\nUnable to locate any plugins to install'));
+    return;
+  }
+
+  console.log(
+    `\nFound ${chalk.green(
+      pluginPaths.length
+    )} plugins to install:\n\t${chalk.green(pluginPaths.join('\n\t'))}`
+  );
+
+  const resolved = await reg.registerPlugins(ymirPath, pluginPaths, force);
+
+  console.log(
+    `\n${chalk.green(
+      resolved.creating.length
+    )} Plugins were installed:\n\t${chalk.green(
+      resolved.creating.join('\n\t')
+    )}`
+  );
+
+  if (resolved.alreadyExists.length !== 0) {
+    console.warn(
+      `\nUse ${chalk.red('[--force|-f]')} to ${chalk.red(
+        'force'
+      )} plugin file update.\n\tThe following plugins were already installed:\n\t\t${chalk.red(
+        resolved.alreadyExists.join('\n\t\t')
+      )}`
+    );
+  }
+
+  if (resolved.resolved.error.length !== 0) {
+    console.error(
+      `\n${chalk.red(
+        'The following plugins had errors:'
+      )}\n\t${resolved.resolved.error.join('\n\t')}`
+    );
+  }
+}
+
+export async function install(args: any, ctx: any) {
+  const { cwd } = ctx;
+  await isInProject(true, ctx);
+  const def = [...legacyInstallDef, ...resolvePluginsDef, help.def];
+
+  const opt = commandLineArgs(def, { argv: args });
+
+  if (opt.help) {
+    return help.log(def, 'Install plugin(s)', help.getUsageText('install'));
+  }
+
+  const hasLegacy = Object.keys(opt).some((key) =>
+    legacyInstallDef.some((def) => def.name === key)
+  );
+
+  if (hasLegacy) return legacyInstall(args, ctx);
+
+  return resolvePlugins(args, ctx);
 }

--- a/packages/ymir-core-cli/src/bin/stack-operation/index.ts
+++ b/packages/ymir-core-cli/src/bin/stack-operation/index.ts
@@ -48,7 +48,7 @@ export async function init(args: any, ctx: any) {
   const pluginPaths = await reg.fullPluginResolve(cwd);
 
   if (pluginPaths.length === 0) {
-    console.warn(chalk.red('\nUnable to locate any plugins to install'));
+    console.warn(chalk.red('Unable to locate any plugins to install'));
     return;
   }
 

--- a/packages/ymir-core-cli/src/bin/stack-operation/index.ts
+++ b/packages/ymir-core-cli/src/bin/stack-operation/index.ts
@@ -7,6 +7,7 @@ import * as coLib from '../../lib/config/stack-operations/checkout';
 import { createNewStack } from '../../lib/config/stack-operations/create-stack';
 import { removeStack } from '../../lib/config/stack-operations/remove-stack';
 import * as edit from '../../lib/config/stack-operations/edit-stack-file';
+import * as reg from '../../lib/plugin/register-plugin';
 
 import {
   isInProject,
@@ -42,6 +43,41 @@ export async function init(args: any, ctx: any) {
   await initLib.init(cwd, opt.relativePath, opt.absolutePath);
 
   console.log(`New ymir project created at ${chalk.green(cwd)}`);
+
+  const ymirPath = helper.ymirProjectFolderPath(cwd);
+  const pluginPaths = await reg.fullPluginResolve(cwd);
+
+  if (pluginPaths.length === 0) {
+    console.warn(chalk.red('\nUnable to locate any plugins to install'));
+    return;
+  }
+
+  console.log(
+    `\nFound ${chalk.green(
+      pluginPaths.length
+    )} plugins to install:\n\t${chalk.green(pluginPaths.join('\n\t'))}`
+  );
+
+  const resolved = await reg.registerPlugins(ymirPath, pluginPaths);
+
+  console.log(
+    `\n${chalk.green(
+      resolved.creating.length
+    )} Plugins were installed:\n\t${chalk.green(
+      resolved.creating.join('\n\t')
+    )}`
+  );
+
+  if (resolved.alreadyExists.length !== 0) {
+    console.warn(
+      `\nUse ${chalk.red('[--force|-f]')} to ${chalk.red(
+        'force'
+      )} plugin file update.\n\tThe following plugins were already installed:\n\t\t${chalk.red(
+        resolved.alreadyExists.join('\n\t\t')
+      )}`
+    );
+  }
+  return;
 }
 
 export async function checkoutStack(args: any, ctx: any) {

--- a/packages/ymir-core-cli/src/bin/stack-operation/index.ts
+++ b/packages/ymir-core-cli/src/bin/stack-operation/index.ts
@@ -1,3 +1,4 @@
+import * as Chalk from 'chalk';
 import * as commandLineArgs from 'command-line-args';
 
 import * as initLib from '../../lib/config/init';
@@ -16,6 +17,8 @@ import {
 } from '../lib/index';
 
 import * as help from '../lib/help';
+
+const chalk: any = Chalk;
 
 /**
  * TODO:
@@ -36,7 +39,9 @@ export async function init(args: any, ctx: any) {
     return help.log(def, 'Init a new ymir project');
   }
 
-  return initLib.init(cwd, opt.relativePath, opt.absolutePath);
+  await initLib.init(cwd, opt.relativePath, opt.absolutePath);
+
+  console.log(`New ymir project created at ${chalk.green(cwd)}`);
 }
 
 export async function checkoutStack(args: any, ctx: any) {

--- a/packages/ymir-core-cli/src/lib/config/init.ts
+++ b/packages/ymir-core-cli/src/lib/config/init.ts
@@ -192,9 +192,9 @@ export async function setupProjectFolder(
     );
 
     // TODO: need to add template data here;
-    await Promise.all(
-      ymirPluginStructure.map((fn) => fn(nodePath.join(path, 'plugins')))
-    );
+    // await Promise.all(
+    //   ymirPluginStructure.map((fn) => fn(nodePath.join(path, 'plugins')))
+    // );
     await stackFileCreatePromises;
     await stackConfigCreatePromises;
     await fs.writeFile(nodePath.join(path, '.gitignore'), '/plugins\n');

--- a/packages/ymir-core-cli/src/lib/config/init.ts
+++ b/packages/ymir-core-cli/src/lib/config/init.ts
@@ -63,32 +63,32 @@ const ymirRootStructure = [
   (basePath: string, data = '[dev]: ./stacks/dev') => {
     const name = 'current_stack';
     const path = nodePath.join(basePath, name);
-    console.log(`Creating file: ${name} at path: ${path}`);
+    // console.log(`Creating file: ${name} at path: ${path}`);
     return fs.writeFile(path, data);
   },
   (basePath: string) => {
     const name = 'stacks';
     const path = nodePath.join(basePath, name);
-    console.log(`Creating dir: ${name} at path: ${path}`);
+    // console.log(`Creating dir: ${name} at path: ${path}`);
     return fs.mkdir(path);
   },
   (basePath: string) => {
     const name = 'stack-config';
     const path = nodePath.join(basePath, name);
-    console.log(`Creating dir: ${name} at path: ${path}`);
+    // console.log(`Creating dir: ${name} at path: ${path}`);
     return fs.mkdir(path);
   },
   (basePath: string) => {
     const name = 'plugins';
     const path = nodePath.join(basePath, name);
-    console.log(`Creating dir: ${name} at path: ${path}`);
+    // console.log(`Creating dir: ${name} at path: ${path}`);
     return fs.mkdir(path);
   },
 ];
 
 async function createNewFile(basePath: string, name: string, data: string) {
   const path = nodePath.join(basePath, name);
-  console.log(`Creating file: ${name} at path: ${path}`);
+  // console.log(`Creating file: ${name} at path: ${path}`);
   return fs.writeFile(path, data);
 }
 
@@ -110,7 +110,7 @@ const ymirPluginStructure = [
   (basePath: string, data = 'stuff from rc here') => {
     const name = 'ssm';
     const path = nodePath.join(basePath, name);
-    console.log(`Creating file: ${name} at path: ${path}`);
+    // console.log(`Creating file: ${name} at path: ${path}`);
     return fs.writeFile(path, data);
   },
 ];
@@ -197,6 +197,7 @@ export async function setupProjectFolder(
     );
     await stackFileCreatePromises;
     await stackConfigCreatePromises;
+    await fs.writeFile(nodePath.join(path, '.gitignore'), '/plugins\n');
     return;
   } catch (error) {
     // TODO: if it fail, we should clean it up, remove the folder, so that we remove any file created;
@@ -218,9 +219,9 @@ export async function init(
     throw new Error(`Ymir config already exists at ${path}`);
   }
 
-  console.log(`Creating Ymir project dir at ${path}...`);
+  // console.log(`Creating Ymir project dir at ${path}...`);
   await createYmirProjectFolder(cwd, relativePath, absolutePath);
-  console.log(`Setting up Ymir project dir at ${path}...`);
+  // console.log(`Setting up Ymir project dir at ${path}...`);
   await setupProjectFolder(cwd, relativePath, absolutePath);
 
   return;

--- a/packages/ymir-core-cli/src/lib/plugin/register-plugin.ts
+++ b/packages/ymir-core-cli/src/lib/plugin/register-plugin.ts
@@ -1,0 +1,186 @@
+/**
+ * Automatically register all plugins.
+ *
+ */
+
+import * as nodePath from 'path';
+
+import { execCommand } from '../cmd';
+import * as fs from '../config/helper/fs';
+import * as trans from '../config/parser/transpiler';
+
+const pluginPrefix = 'ymir-plugin-';
+
+export async function getNodeModulesPath(global = false) {
+  const baseCmd = 'npm root';
+  const cmd = global ? `${baseCmd} -g` : baseCmd;
+  const path = await execCommand(cmd);
+  return path.trim();
+}
+
+export async function lsNodeModules(path: string) {
+  return fs.readdir(path);
+}
+
+export async function crawlNodeModules(pathPrefix: string, crawl: string[]) {
+  const pkgs = [];
+  const subDir = await Promise.all(crawl.map((c) => fs.readdir(c)));
+  subDir.forEach((dir, index) => {
+    dir.forEach((d) => {
+      const fullPath = nodePath.join(crawl[index], d);
+      if (d.substring(0, 12) === pluginPrefix) {
+        pkgs.push(fullPath);
+      }
+    });
+  });
+  return pkgs;
+}
+
+export async function locatePlugins(pathPrefix: string) {
+  const dir = await lsNodeModules(pathPrefix);
+  const pluginPaths = [];
+  const crawl = [];
+  dir.forEach((d) => {
+    const fullPath = nodePath.join(pathPrefix, d);
+    if (d.substring(0, 12) === pluginPrefix) {
+      pluginPaths.push(fullPath);
+    }
+    if (d.substring(0, 1) === '@') {
+      crawl.push(fullPath);
+    }
+  });
+
+  const crawled = await crawlNodeModules(pathPrefix, crawl);
+
+  return [...pluginPaths, ...crawled];
+}
+
+export async function extractPluginFromPkJson(path: string) {
+  const pk = await import(path);
+  const { devDependencies, dependencies } = pk;
+  const deps = Object.keys({ ...devDependencies, ...dependencies });
+  // TODO: clean this up;
+  const plugins = deps
+    .map((d) => {
+      if (d.substring(0, 1) === '@') {
+        const plugin = d.split('/')[1];
+        if (plugin.substring(0, 12) === pluginPrefix) {
+          return nodePath.join(path, '..', 'node_modules', d);
+        }
+      }
+      if (d.substring(0, 12) === pluginPrefix) {
+        return nodePath.join(path, '..', 'node_modules', d);
+      }
+      return false;
+    })
+    .filter(Boolean);
+  return plugins;
+}
+
+export async function crawlProjectForPkJson(
+  cwd: string,
+  pkJsonPaths = [],
+  depth = 0,
+  maxDepth = 5
+) {
+  const paths = [...pkJsonPaths];
+  const pkPath = nodePath.join(cwd, 'package.json');
+  const exists = await fs.exists(pkPath);
+  if (exists) {
+    paths.push(pkPath);
+  }
+  if (depth < maxDepth) {
+    const parent = nodePath.join(cwd, '..');
+    return crawlProjectForPkJson(parent, paths, depth + 1, maxDepth);
+  }
+  return paths;
+}
+
+export async function crawlAndLocatePlugins(cwd: string) {
+  const pkJsonPaths = await crawlProjectForPkJson(cwd);
+  return pkJsonPaths.reduce(async (acc, p) => {
+    const res = await acc;
+    const resolve = await extractPluginFromPkJson(p);
+    return [...res, ...resolve];
+  }, Promise.resolve([]));
+}
+
+export async function fullPluginResolve(cwd: string) {
+  const projectRoot = await getNodeModulesPath();
+  const globalRoot = await getNodeModulesPath(true);
+
+  const pluginsRoot = await locatePlugins(projectRoot);
+  const pluginsGlobal = await locatePlugins(globalRoot);
+  const pluginsCrawl = await crawlAndLocatePlugins(cwd);
+
+  const pluginLocations = [
+    ...new Set([...pluginsRoot, ...pluginsGlobal, ...pluginsCrawl]),
+  ];
+
+  return pluginLocations;
+}
+
+// TODO: move to plugin get
+export async function getPluginInfo(path: string) {
+  const plugin = await import(path);
+  const hasInfo = plugin && Object.hasOwnProperty.call(plugin, 'info');
+  if (!hasInfo) {
+    return [
+      {
+        code: 'PLUGIN_MISSING_METHOD',
+        message: `Plugin ${path} is missing the info method`,
+      },
+      null,
+    ];
+  }
+  return [null, await plugin.info()];
+}
+
+export function createPluginFileData(info: any) {
+  const data = {
+    DESCRIBE: {
+      alias: info.alias,
+      pk_name: info.name,
+      pk_version: info.version,
+    },
+    LOCATION: {
+      path: info.installPath,
+      install_cmd: `npm i -D ${info.name}`,
+    },
+  };
+  return trans.transpileObjectToStack(data, {}, ['alias', 'path']);
+}
+
+export async function registerPlugins(
+  ymirPath: string,
+  pluginPaths: string[],
+  overwrite = false
+) {
+  const plugins = await pluginPaths.reduce(
+    async (acc, path): Promise<{ error: any; result: any; files: any }> => {
+      const res = await acc;
+      const [error, info] = await getPluginInfo(path);
+      if (error) res.error.push(error);
+      res.result.push(info);
+      const fileData = createPluginFileData(info);
+      const filePath = nodePath.join(ymirPath, 'plugins', info.alias);
+      res.files.push([filePath, fileData]);
+      return res;
+    },
+    Promise.resolve({ error: [], result: [], files: [] })
+  );
+
+  const { files } = plugins;
+  const fileWrites = files.map(async ([path, data]) => {
+    if (!overwrite) {
+      const exists = await fs.exists(path);
+      if (exists) {
+        console.log(`Plugin ${path} already exists, skipping`);
+        return null;
+      }
+    }
+    return fs.writeFile(path, data);
+  });
+
+  await Promise.all(fileWrites);
+}

--- a/packages/ymir-plugin-azure-key-vault/package.json
+++ b/packages/ymir-plugin-azure-key-vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onevor/ymir-plugin-azure-key-vault",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Resolver plugin for azure key vault",
   "main": "./src/index.js",
   "homepage": "https://onevor.no/",

--- a/packages/ymir-plugin-azure-key-vault/src/lib/ymir-plugin-azure-key-vault.ts
+++ b/packages/ymir-plugin-azure-key-vault/src/lib/ymir-plugin-azure-key-vault.ts
@@ -1,3 +1,5 @@
+import * as nodePath from 'path';
+
 import { SecretClient, KeyVaultSecret } from '@azure/keyvault-secrets';
 import { DefaultAzureCredential } from '@azure/identity';
 
@@ -128,4 +130,17 @@ export async function importEnv(
   }
 
   return [null, properties];
+}
+
+export async function info() {
+  const pk = await import('../../package.json');
+  const installPath = nodePath.join(__dirname, '../../');
+  const { name, version } = pk;
+  return {
+    name,
+    version,
+    alias: 'keyvault',
+    requiredConfig: ['vault_name'],
+    installPath,
+  };
 }

--- a/packages/ymir-plugin-ssm/package.json
+++ b/packages/ymir-plugin-ssm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onevor/ymir-plugin-ssm",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Ymir resolver for AWS SSM",
   "main": "./src/index.js",
   "homepage": "https://onevor.no/",

--- a/packages/ymir-plugin-ssm/src/lib/ymir-plugin-ssm.ts
+++ b/packages/ymir-plugin-ssm/src/lib/ymir-plugin-ssm.ts
@@ -1,6 +1,4 @@
-/**
- * This is a mock plugin: I have yet to design the plugin structure.
- */
+import * as nodePath from 'path';
 
 import { SSM } from './ssm';
 import { randomUUID } from 'crypto';
@@ -134,4 +132,17 @@ export async function importEnv(
   }
 
   return [null, properties];
+}
+
+export async function info() {
+  const pk = await import('../../package.json');
+  const installPath = nodePath.join(__dirname, '../../');
+  const { name, version } = pk;
+  return {
+    name,
+    version,
+    alias: 'ssm',
+    requiredConfig: ['region'],
+    installPath,
+  };
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,7 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
+    "resolveJsonModule": true,
     "paths": {
       "@onevor/ymir-core-cli": ["packages/ymir-core-cli/src/index.ts"],
       "@onevor/ymir-plugin-azure-key-vault": [


### PR DESCRIPTION
# Auto resolve plugins

## You used to have to do:
`ymir install --path full_path_to_installes_plugin --alias a-short-name-for-plugin`

## Now you can do:
`ymir install`

Given that you have installed a plugin with npm:
`npm i @onevor/ymir-plugin-[name]`

**Ymir** will check the global node_modules, root npm_modules, and we crawl file system 5 levels up from **YmirPath** for package.json file.
if we find a plugin, we ask it to give us it's own info by calling **`plugin.info()`**

A plugin is defined as a npm pk where the **name** starts with `ymir-plugin-` or `@[domain]/ymir-plugin-`