### PR TITLE
Small cli improvements from user feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19179,7 +19179,7 @@
     },
     "packages/ymir-core-cli": {
       "name": "@onevor/ymir-core-cli",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "ISC",
       "dependencies": {
         "chalk": "^4.0.0",

--- a/packages/ymir-core-cli/package-lock.json
+++ b/packages/ymir-core-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onevor/ymir-core-cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onevor/ymir-core-cli",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "ISC",
       "dependencies": {
         "command-line-args": "^5.2.1",

--- a/packages/ymir-core-cli/package.json
+++ b/packages/ymir-core-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onevor/ymir-core-cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Manage app config and secrets",
   "main": "index.js",
   "private": false,

--- a/packages/ymir-core-cli/src/bin/resolve/export.ts
+++ b/packages/ymir-core-cli/src/bin/resolve/export.ts
@@ -1,17 +1,11 @@
-import * as nodePath from 'path';
-
 import * as commandLineArgs from 'command-line-args';
 
 import * as helper from '../../lib/config/helper';
 import * as fs from '../../lib/config/helper/fs';
-import * as resolverLib from '../../lib/resolve/lib/resolver-operations/resolve-stack';
-import * as getPlugin from '../../lib/plugin/get-plugin';
-import * as getStack from '../../lib/stack/get';
+import plugin from '../../lib/plugin';
 
 import { isInProject } from '../lib/index';
 import * as help from '../lib/help';
-
-import { entriesToEnvFile } from '../../lib/dotfile';
 
 export async function exportStack(args: any, ctx: any) {
   const { cwd } = ctx;
@@ -33,43 +27,5 @@ export async function exportStack(args: any, ctx: any) {
     return;
   }
 
-  // const [stack, defaultStack, stackConfig, defaultStackConfig] =
-  const stackSource = await getStack.stackSource(ymirPath, stackName);
-  const [defaultResolverErr, defaultResolver] =
-    getPlugin.defaultResolver(stackSource);
-
-  if (defaultResolverErr) {
-    console.error(defaultResolverErr.message, defaultResolverErr);
-    return;
-  }
-
-  const [resolverConfErr, resolverConf] = await getPlugin.configByStackSource(
-    ymirPath,
-    stackSource
-  );
-
-  if (resolverConfErr) {
-    console.error('Unable to create resolver config: ', resolverConfErr);
-    return;
-  }
-
-  const data = getPlugin.parseFiles(stackSource);
-
-  const resolved = await resolverLib.resolveStack(
-    ymirPath,
-    data,
-    defaultResolver,
-    resolverConf
-  );
-
-  const dotFileData = entriesToEnvFile(resolved);
-  const fileConf = data.stackConfig.FILE || data.defaultStackConfig.FILE;
-
-  if (!fileConf) {
-    console.error('No FILE config found in stack or default stack');
-    return;
-  }
-
-  const filePath = nodePath.join(ymirPath, '../', fileConf.path, fileConf.name);
-  return fs.writeFile(filePath, dotFileData);
+  return plugin.export(ymirPath, stackName);
 }

--- a/packages/ymir-core-cli/src/bin/stack-operation/index.ts
+++ b/packages/ymir-core-cli/src/bin/stack-operation/index.ts
@@ -153,7 +153,12 @@ export async function stack(args: any, ctx: any) {
   const { cwd } = ctx;
   await isInProject(true, ctx);
   const def = [
-    { name: 'list', alias: 'l', type: Boolean, description: 'List all stacks' },
+    {
+      name: 'current',
+      alias: 'c',
+      type: Boolean,
+      description: 'Only list the current stack',
+    },
     {
       name: 'path',
       alias: 'p',
@@ -173,14 +178,14 @@ export async function stack(args: any, ctx: any) {
   const ymirPath = helper.ymirProjectFolderPath(cwd);
   const [name, location] = await helper.getCurrentStack(ymirPath);
 
-  const currentStackName = opt.list ? `* ${name}` : name;
+  const currentStackName = chalk.green(opt.current ? name : `* ${name}`);
   const stackRecord = opt.path
     ? `${currentStackName} @(${location})`
     : currentStackName;
 
   stacks.push(stackRecord);
 
-  if (opt.list) {
+  if (!opt.current) {
     const [fileNames, path] = await helper.getAllStackFileNames(ymirPath);
     fileNames.forEach((stackName) => {
       if (stackName !== name) {
@@ -189,11 +194,7 @@ export async function stack(args: any, ctx: any) {
     });
   }
 
-  if (opt.list) {
-    console.log(`Stacks:\n\t${stacks.join('\n\t')}`);
-    return;
-  }
-  console.log(`Current stack:\n\t${stacks.join('\n\t')}`);
+  console.log(`\t${stacks.join('\n\t')}`);
   return;
 }
 

--- a/packages/ymir-core-cli/src/lib/plugin/export.ts
+++ b/packages/ymir-core-cli/src/lib/plugin/export.ts
@@ -1,0 +1,49 @@
+import * as nodePath from 'path';
+
+import * as fs from '../config/helper/fs';
+import * as resolverLib from '../resolve/lib/resolver-operations/resolve-stack';
+import * as getPlugin from '../plugin/get-plugin';
+import * as getStack from '../stack/get';
+
+import { entriesToEnvFile } from '../dotfile';
+
+export async function _export(ymirPath: string, stackName: string) {
+  const stackSource = await getStack.stackSource(ymirPath, stackName);
+  const [defaultResolverErr, defaultResolver] =
+    getPlugin.defaultResolver(stackSource);
+
+  if (defaultResolverErr) {
+    console.error(defaultResolverErr.message, defaultResolverErr);
+    return;
+  }
+
+  const [resolverConfErr, resolverConf] = await getPlugin.configByStackSource(
+    ymirPath,
+    stackSource
+  );
+
+  if (resolverConfErr) {
+    console.error('Unable to create resolver config: ', resolverConfErr);
+    return;
+  }
+
+  const data = getPlugin.parseFiles(stackSource);
+
+  const resolved = await resolverLib.resolveStack(
+    ymirPath,
+    data,
+    defaultResolver,
+    resolverConf
+  );
+
+  const dotFileData = entriesToEnvFile(resolved);
+  const fileConf = data.stackConfig.FILE || data.defaultStackConfig.FILE;
+
+  if (!fileConf) {
+    console.error('No FILE config found in stack or default stack');
+    return;
+  }
+
+  const filePath = nodePath.join(ymirPath, '../', fileConf.path, fileConf.name);
+  return fs.writeFile(filePath, dotFileData);
+}

--- a/packages/ymir-core-cli/src/lib/plugin/index.ts
+++ b/packages/ymir-core-cli/src/lib/plugin/index.ts
@@ -1,0 +1,9 @@
+import { _export } from './export';
+import * as get from './get-plugin';
+
+const plugin = {
+  export: _export,
+  get,
+};
+
+export default plugin;


### PR DESCRIPTION
`ymir stack` now lists all your stacks by default without any header text:
can add: `--current|-c` to get only the current stack
**Before**:
```
Current stack:
    dev
```
**Now**:
```
  * dev
  stage
  prod
````

`ymir checkout <stack-name>`: now exports the stack by default
can add `--ignoreExport|-i` to not export
